### PR TITLE
Change cursor on collapse sidebar

### DIFF
--- a/changelog/_unreleased/2022-10-19-change-cursor-on-collapse-sidebar.md
+++ b/changelog/_unreleased/2022-10-19-change-cursor-on-collapse-sidebar.md
@@ -1,0 +1,10 @@
+---
+title: Change cursor on collapse sidebar in administration
+issue:
+flag:
+author: Janine Meyer
+author_email: meyer@heptacom.de
+author_github: @janiilicious
+---
+# Administration
+* Changed the cursor in sw-sidebar-collaps.scss from .sw-sidebar-collapse__header to .sw-sidebar-collapse__title and .sw-sidebar-collapse__indicator so .sw-sidebar-collapse__action doesn't appear as clickable.

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collaps.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collaps.scss
@@ -8,7 +8,6 @@ $sw-sidebar-collapse-font-size-title: $font-size-default;
     .sw-sidebar-collapse__header {
         display: grid;
         grid-template-columns: 1fr 1fr auto;
-        cursor: pointer;
         padding-top: 16px;
         padding-bottom: 16px;
         color: $sw-sidebar-collapse-color-title;
@@ -19,13 +18,18 @@ $sw-sidebar-collapse-font-size-title: $font-size-default;
         font-size: $sw-sidebar-collapse-font-size-title;
         font-weight: $font-weight-regular;
         margin: 0 25px;
+        cursor: pointer;
     }
 
-    .sw-sidebar-collapse__button {
-        margin-right: 25px;
+    .sw-sidebar-collapse__indicator {
+        cursor: pointer;
 
-        &.is--hidden {
-            display: none;
+        .sw-sidebar-collapse__button {
+            margin-right: 25px;
+
+            &.is--hidden {
+                display: none;
+            }
         }
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Because it's irritating to have an unclickable area even though you see the cursor as a pointer.

### 2. What does this change do, exactly?
Changed the cursor in sw-sidebar-collaps.scss from .sw-sidebar-collapse__header to .sw-sidebar-collapse__title and .sw-sidebar-collapse__indicator so .sw-sidebar-collapse__action doesn't appear as clickable.

### 3. Describe each step to reproduce the issue or behaviour.
Go to the administration in the category overview and try to click next to the title. Nothing happens.

<img width="484" alt="irritating cursor next to the collapse title" src="https://user-images.githubusercontent.com/67735705/196748387-0a7fbc8a-fd77-4309-bfb8-e41de1c2702d.png">
<img width="541" alt="the grid" src="https://user-images.githubusercontent.com/67735705/196748384-bf18af69-6784-49c7-a4fa-ab92a51bc591.png">

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
